### PR TITLE
feat: implement ask slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Discord Bot MVP — Gemini Flash + AWS Lambda (TypeScript, CDK)
 
 This repo is a **steering document + skeleton** to ship an MVP Discord bot:
-- **Slash commands**: `/ask <prompt>`, `/help`
+- **Slash commands**: `/ask question:<text> [private:true]`, `/help`
 - **Infra**: AWS **Lambda** + **API Gateway (HTTP API)** + **Secrets Manager**
 - **Runtime**: TypeScript on Node.js 20
 - **IaC**: AWS **CDK v2** (TypeScript)
@@ -12,7 +12,7 @@ This repo is a **steering document + skeleton** to ship an MVP Discord bot:
 
 ## MVP Scope
 
-- `/ask <prompt>` → answer via Gemini Flash (ephemeral by default).
+- `/ask question:<text>` → answer via Gemini Flash (public by default; add `private:true` for ephemeral).
 - `/help` → short usage/help text.
 - Interaction verification (Ed25519) on **every** request.
 - Defer when work > 2s; send follow‑up webhook message.
@@ -55,7 +55,6 @@ This repo is a **steering document + skeleton** to ship an MVP Discord bot:
 - `SECRETS_DISCORD_TOKEN_NAME`
 - `SECRETS_DISCORD_PUBLIC_KEY_NAME`
 - `SECRETS_GEMINI_API_KEY_NAME`
-- `EPHEMERAL_DEFAULT=true`
 - `MODEL_ID=gemini-1.5-flash`
 - `RESPONSE_MAX_TOKENS=1024`
 - `TIMEOUT_MS=9000`

--- a/infra/lib/discord-bot-stack.ts
+++ b/infra/lib/discord-bot-stack.ts
@@ -32,7 +32,6 @@ export class DiscordBotStack extends cdk.Stack {
         SECRETS_DISCORD_TOKEN_NAME: discordToken.secretName,
         SECRETS_DISCORD_PUBLIC_KEY_NAME: discordPublicKey.secretName,
         SECRETS_GEMINI_API_KEY_NAME: geminiApiKey.secretName,
-        EPHEMERAL_DEFAULT: 'true',
         MODEL_ID: 'gemini-1.5-flash',
         RESPONSE_MAX_TOKENS: '1024',
         TIMEOUT_MS: '9000',

--- a/runtime/src/discord/types.ts
+++ b/runtime/src/discord/types.ts
@@ -4,11 +4,15 @@ export interface Interaction {
   type: InteractionType;
   id: string;
   token: string;
+  application_id: string;
   data?: {
     name?: string;
-    options?: { name: string; value: string }[];
+    options?: { name: string; value: string | boolean }[];
   };
   guild_id?: string;
+  channel_id?: string;
+  member?: { user?: { id: string } };
+  user?: { id: string };
 }
 
 export interface DiscordResponse {

--- a/scripts/register-commands.ts
+++ b/scripts/register-commands.ts
@@ -1,6 +1,67 @@
+import { request } from 'undici';
 
 /**
- * Placeholder script to register slash commands via Discord REST API.
- * Fill in your application ID, bot token, and desired commands.
+ * Register slash commands with Discord.
+ * Requires environment variables:
+ * - DISCORD_APP_ID
+ * - DISCORD_BOT_TOKEN
+ * Optional:
+ * - DISCORD_GUILD_ID (register commands for a single guild if set)
  */
-console.log('TODO: implement slash command registration');
+async function main() {
+  const appId = process.env.DISCORD_APP_ID;
+  const token = process.env.DISCORD_BOT_TOKEN;
+  const guildId = process.env.DISCORD_GUILD_ID;
+
+  if (!appId || !token) {
+    throw new Error('DISCORD_APP_ID and DISCORD_BOT_TOKEN must be set');
+  }
+
+  const commands = [
+    {
+      name: 'ask',
+      description: 'Ask Gemini a question',
+      options: [
+        {
+          type: 3,
+          name: 'question',
+          description: 'The question to ask (max 250 chars)',
+          required: true,
+          max_length: 250,
+        },
+        {
+          type: 5,
+          name: 'private',
+          description: 'Respond only to you',
+          required: false,
+        },
+      ],
+    },
+    { name: 'help', description: 'How to use this bot' },
+  ];
+
+  const url = guildId
+    ? `https://discord.com/api/v10/applications/${appId}/guilds/${guildId}/commands`
+    : `https://discord.com/api/v10/applications/${appId}/commands`;
+
+  const res = await request(url, {
+    method: 'PUT',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bot ${token}`,
+    },
+    body: JSON.stringify(commands),
+  });
+
+  if (res.statusCode >= 400) {
+    const body = await res.body.text();
+    throw new Error(`Discord API error ${res.statusCode}: ${body}`);
+  }
+
+  console.log('Registered slash commands');
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add registration script for ask/help commands
- implement `/ask` interaction with validation, optional private replies, and follow-up webhook
- document new command syntax and update stack env vars

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: No inputs were found in config file)*
- `npm --prefix runtime run build`
- `npm --prefix infra run build`


------
https://chatgpt.com/codex/tasks/task_e_6897b6f9a1c48326b69632378c340862