### PR TITLE
feat: implement help command handler

### DIFF
--- a/runtime/src/handlers/interactions.ts
+++ b/runtime/src/handlers/interactions.ts
@@ -46,13 +46,7 @@ export const handler = async (event: APIGatewayProxyEventV2): Promise<APIGateway
       const name = interaction.data.name;
 
       if (name === 'help') {
-        return json({
-          type: 4,
-          data: {
-            content: 'Use `/ask <prompt>` to query Gemini. Replies are ephemeral by default.',
-            flags: EPHEMERAL_FLAG,
-          },
-        });
+        return json(handleHelp());
       }
 
       if (name === 'ask') {
@@ -120,6 +114,29 @@ export const handler = async (event: APIGatewayProxyEventV2): Promise<APIGateway
     });
   }
 };
+
+export function handleHelp(): DiscordResponse {
+  return {
+    type: 4,
+    data: {
+      content: generateHelpMessage(),
+      flags: EPHEMERAL_FLAG,
+    },
+  };
+}
+
+export function generateHelpMessage(): string {
+  const msg = [
+    'Need assistance? Use `/ask <prompt>` to query the Gemini model.',
+    'The bot replies only to you so conversations stay private.',
+    '',
+    'Example:',
+    '`/ask How do I write a Lambda?`',
+  ].join('\n');
+
+  // Sanitize and ensure we respect Discord limits (2000 char max)
+  return sanitizeForDiscord(msg).slice(0, 2000);
+}
 
 function sanitizeForDiscord(s: string): string {
   // Minimal sanitization to avoid accidental mentions


### PR DESCRIPTION
## Summary
- add `/help` command handler and sanitized help message
- route `help` slash command to the new handler

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: No inputs were found in config file)*
- `npx tsc runtime/src/handlers/interactions.ts --noEmit` *(fails: Module can only be default-imported using the 'esModuleInterop' flag)*

------
https://chatgpt.com/codex/tasks/task_e_6897b8419e848326aefae9f356f51e9c