### PR TITLE
feat: add interaction router

### DIFF
--- a/runtime/src/discord/types.ts
+++ b/runtime/src/discord/types.ts
@@ -20,5 +20,6 @@ export interface DiscordResponse {
   data?: {
     content?: string;
     flags?: number;
+    allowed_mentions?: { parse?: string[] };
   };
 }

--- a/runtime/src/handlers/interaction_router.ts
+++ b/runtime/src/handlers/interaction_router.ts
@@ -1,0 +1,69 @@
+export type Interaction = import('../discord/types').Interaction;
+export type DiscordResponse = import('../discord/types').DiscordResponse;
+
+const EPHEMERAL_FLAG = 64;
+
+export const routeInteraction = (interaction: Interaction): DiscordResponse => {
+  if (interaction.type === 1) {
+    return { type: 1 };
+  }
+
+  if (interaction.type === 2 && interaction.data?.name) {
+    const name = interaction.data.name;
+
+    if (name === 'help') {
+      return {
+        type: 4,
+        data: {
+          content: 'Use `/ask question:<text> [private:true]` to ask a question. Use `/help` to see this message.',
+          flags: EPHEMERAL_FLAG,
+        },
+      };
+    }
+
+    if (name === 'ask') {
+      const opts = interaction.data.options ?? [];
+      const questionOpt = opts.find(o => o.name === 'question');
+      const privateOpt = opts.find(o => o.name === 'private');
+
+      const question =
+        typeof questionOpt?.value === 'string' ? questionOpt.value.trim() : '';
+      const isPrivate = privateOpt?.value === true;
+
+      if (!question) {
+        return {
+          type: 4,
+          data: {
+            content: 'Usage: /ask question:<text> [private:true]',
+            flags: EPHEMERAL_FLAG,
+          },
+        };
+      }
+
+      return {
+        type: 4,
+        data: {
+          content: 'Processing your question…',
+          ...(isPrivate ? { flags: EPHEMERAL_FLAG } : {}),
+        },
+      };
+    }
+
+    return {
+      type: 4,
+      data: {
+        content: `Unknown command: ${name}`,
+        flags: EPHEMERAL_FLAG,
+      },
+    };
+  }
+
+  return {
+    type: 4,
+    data: {
+      content: 'Unsupported interaction type',
+      flags: EPHEMERAL_FLAG,
+    },
+  };
+};
+

--- a/runtime/src/handlers/interaction_router.ts
+++ b/runtime/src/handlers/interaction_router.ts
@@ -2,6 +2,9 @@ export type Interaction = import('../discord/types').Interaction;
 export type DiscordResponse = import('../discord/types').DiscordResponse;
 
 const EPHEMERAL_FLAG = 64;
+const ALLOWED_NONE = { parse: [] as string[] };
+const USAGE_ASK = 'Usage: /ask question:<text> [private:true]';
+const USAGE_HELP = 'Use `/ask question:<text> [private:true]` to ask a question. Use `/help` to see this message.';
 
 export const routeInteraction = (interaction: Interaction): DiscordResponse => {
   if (interaction.type === 1) {
@@ -9,14 +12,15 @@ export const routeInteraction = (interaction: Interaction): DiscordResponse => {
   }
 
   if (interaction.type === 2 && interaction.data?.name) {
-    const name = interaction.data.name;
+    const name = String(interaction.data.name).toLowerCase();
 
     if (name === 'help') {
       return {
         type: 4,
         data: {
-          content: 'Use `/ask question:<text> [private:true]` to ask a question. Use `/help` to see this message.',
+          content: USAGE_HELP,
           flags: EPHEMERAL_FLAG,
+          allowed_mentions: ALLOWED_NONE,
         },
       };
     }
@@ -28,14 +32,16 @@ export const routeInteraction = (interaction: Interaction): DiscordResponse => {
 
       const question =
         typeof questionOpt?.value === 'string' ? questionOpt.value.trim() : '';
-      const isPrivate = privateOpt?.value === true;
+      // Be defensive in case value is not strictly boolean at runtime
+      const isPrivate = privateOpt?.value === true || privateOpt?.value === 'true';
 
       if (!question) {
         return {
           type: 4,
           data: {
-            content: 'Usage: /ask question:<text> [private:true]',
+            content: USAGE_ASK,
             flags: EPHEMERAL_FLAG,
+            allowed_mentions: ALLOWED_NONE,
           },
         };
       }
@@ -45,6 +51,7 @@ export const routeInteraction = (interaction: Interaction): DiscordResponse => {
         data: {
           content: 'Processing your question…',
           ...(isPrivate ? { flags: EPHEMERAL_FLAG } : {}),
+          allowed_mentions: ALLOWED_NONE,
         },
       };
     }
@@ -54,6 +61,7 @@ export const routeInteraction = (interaction: Interaction): DiscordResponse => {
       data: {
         content: `Unknown command: ${name}`,
         flags: EPHEMERAL_FLAG,
+        allowed_mentions: ALLOWED_NONE,
       },
     };
   }
@@ -63,6 +71,7 @@ export const routeInteraction = (interaction: Interaction): DiscordResponse => {
     data: {
       content: 'Unsupported interaction type',
       flags: EPHEMERAL_FLAG,
+      allowed_mentions: ALLOWED_NONE,
     },
   };
 };


### PR DESCRIPTION
## Summary
- add pure router for Discord interactions
- handle `/help` and `/ask` commands with ephemeral responses

## Testing
- `npx tsc --noEmit src/handlers/interaction_router.ts`


------
https://chatgpt.com/codex/tasks/task_e_6897c28aafec8326809b2a4dd4e35138