### PR TITLE
Add Secrets Manager helper utility

### DIFF
--- a/runtime/src/util/secrets.ts
+++ b/runtime/src/util/secrets.ts
@@ -1,0 +1,9 @@
+import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
+
+const client = new SecretsManagerClient({});
+
+export async function getSecretString(secretId: string): Promise<string> {
+  const out = await client.send(new GetSecretValueCommand({ SecretId: secretId }));
+  if (!out.SecretString) throw new Error(`Secret ${secretId} has no SecretString`);
+  return out.SecretString;
+}


### PR DESCRIPTION
## Summary
- add runtime helper for fetching secrets from AWS Secrets Manager

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897c29812a88326b9fa0b87a48f194d