### PR TITLE
feat: add deterministic mock ask helper

### DIFF
--- a/runtime/src/gemini/ask.ts
+++ b/runtime/src/gemini/ask.ts
@@ -1,0 +1,6 @@
+export type AskParams = { prompt: string; maxTokens?: number };
+
+export async function askFastMock({ prompt }: AskParams): Promise<string> {
+  // Short, deterministic answer for tests
+  return `Mocked answer to: ${prompt.slice(0, 100)}`;
+}


### PR DESCRIPTION
## Summary
- add `askFastMock` helper to Gemini runtime for deterministic mock responses

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897c2b9fda48326981309b9319bee99